### PR TITLE
Fix for concurrent builds in claim integration

### DIFF
--- a/src/main/java/hudson/model/JobViewEntry.java
+++ b/src/main/java/hudson/model/JobViewEntry.java
@@ -412,7 +412,7 @@ public class JobViewEntry implements IViewEntry {
 		if (Hudson.getInstance().getPlugin("claim") != null) {
 			claim = NOT_CLAIMED;
 			Run lastBuild = job.getLastBuild();
-			if (lastBuild != null && lastBuild.isBuilding()) {
+			while (lastBuild != null && lastBuild.isBuilding()) {
 				// claims can only be made against builds once they've finished,
 				// so check the previous build if currently building.
 				lastBuild = lastBuild.getPreviousBuild();


### PR DESCRIPTION
This patch fixes the claim integration, showing claims properly, when several builds are building concurrently.

The last pull request accidentally included more commits than I intended.
