### PR TITLE
Adding a project name to the job to group them by it, on Radiator View

### DIFF
--- a/src/main/java/hudson/model/IViewEntry.java
+++ b/src/main/java/hudson/model/IViewEntry.java
@@ -13,6 +13,11 @@ public interface IViewEntry {
 	public abstract String getName();
 
 	/**
+	 * @return the job's radiator project name
+	 */
+	public abstract String getProjectName();
+
+	/**
 	 * @return if this job is queued for build
 	 */
 	public abstract Boolean getQueued();

--- a/src/main/java/hudson/model/JobViewEntry.java
+++ b/src/main/java/hudson/model/JobViewEntry.java
@@ -75,6 +75,16 @@ public class JobViewEntry implements IViewEntry {
 	/*
 	 * (non-Javadoc)
 	 * 
+	 * @see hudson.model.IViewEntry#getProjectName()
+	 */
+	public String getProjectName() {
+		RadiatorProjectProperty rpp = job.getProperty(RadiatorProjectProperty.class);
+		return (rpp != null) ? rpp.projectName : "";
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
 	 * @see hudson.model.IViewEntry#getQueued()
 	 */
 	public Boolean getQueued() {

--- a/src/main/java/hudson/model/ProjectViewEntry.java
+++ b/src/main/java/hudson/model/ProjectViewEntry.java
@@ -81,11 +81,15 @@ public class ProjectViewEntry implements IViewEntry {
 		return name;
 	}
 
+	public String getProjectName() {
+		return name;
+	}
+
 	public void addBuild(IViewEntry entry) {
 		Validate.notNull(entry);
 		jobs.add(entry);
 	}
-	
+
 	public String getStatus()
 	{
 		if (getBroken() || getFailCount() > 0)

--- a/src/main/java/hudson/model/RadiatorProjectProperty.java
+++ b/src/main/java/hudson/model/RadiatorProjectProperty.java
@@ -1,0 +1,48 @@
+package hudson.model;
+
+import hudson.Extension;
+import net.sf.json.JSONObject;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+
+public final class RadiatorProjectProperty extends
+		JobProperty<AbstractProject<?, ?>> {
+
+	public final String projectName;
+
+	@DataBoundConstructor
+	public RadiatorProjectProperty(final String projectName) {
+
+		this.projectName = projectName;
+	}
+
+	@Extension
+	public static final class DescriptorImpl extends JobPropertyDescriptor {
+
+		public DescriptorImpl() {
+			super(RadiatorProjectProperty.class);
+			load();
+		}
+
+		@Override
+		public boolean isApplicable(Class<? extends Job> jobType) {
+			return AbstractProject.class.isAssignableFrom(jobType);
+		}
+
+		@Override
+		public String getDisplayName() {
+			return "Radiator project name";
+		}
+
+		@Override
+		public JobProperty<?> newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+
+			if (formData.isEmpty()) {
+				return null;
+			}
+
+			return new RadiatorProjectProperty(formData.getString("projectName"));
+		}
+	}
+}

--- a/src/main/java/hudson/model/RadiatorView.java
+++ b/src/main/java/hudson/model/RadiatorView.java
@@ -135,7 +135,8 @@ public class RadiatorView extends ListView {
 		
 		for (IViewEntry job: allContents.getJobs())
 		{
-			String prefix = getPrefix(job.getName());
+			String projectName = job.getProjectName();
+			String prefix = StringUtils.isEmpty(projectName) ? getPrefix(job.getName()) : projectName;
 			ProjectViewEntry project = jobsByPrefix.get(prefix);
 			if (project == null)
 			{

--- a/src/main/resources/hudson/model/RadiatorProjectProperty/config.jelly
+++ b/src/main/resources/hudson/model/RadiatorProjectProperty/config.jelly
@@ -1,0 +1,15 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <!--
+    This jelly script is used for per-project configuration.
+
+    See global.jelly for a general discussion about jelly script.
+  -->
+
+  <!--
+    Creates a text field that shows the value of the "name" property.
+    When submitted, it will be passed to the corresponding constructor parameter.
+  -->
+  <f:entry title="${descriptor.getDisplayName()}" field="projectName">
+    <f:textbox />
+  </f:entry>
+</j:jelly>


### PR DESCRIPTION
If the user want, can set a project name to the job.
Jobs with same project name will be grouped on Radiator View.
