### PR TITLE
Some minor spacing detail updates

### DIFF
--- a/src/main/resources/hudson/model/RadiatorView/jobs.jelly
+++ b/src/main/resources/hudson/model/RadiatorView/jobs.jelly
@@ -41,14 +41,14 @@
 
 
 		<j:set var="height" value="${(failJobsHeight / failJobRows.size())}" />
-		<j:set var="top" value="0" />
+		<j:set var="top" value="1" />
 		<j:set var="showDetail" value="true" />
 		<j:forEach var="row" items="${failJobRows}">
 			<j:set var="width" value="${(100 / row.size())}" />
 			<j:set var="left" value="0" />
 			<j:forEach var="job" items="${row}">
 				<j:set var="jobStyle"
-					value="left: ${left}%; top:${top}%; width:${width-3}%; height:${height-2}%; margin:1%; padding-left: 1%;" />
+					value="left: ${left}%; top:${top}%; width:${width-1.4}%; height:${height-2}%; margin:.2%; padding-left: 1%;" />
 				<st:include page="job.jelly" />
 				<j:set var="left" value="${left + width}" />
 			</j:forEach>


### PR DESCRIPTION
### Overview

I've added some padding to the job divs so that the text is a little more separated from the div wall. I've also allowed the failed jobs to fill the blank space a little more, so they don't look so weird when you have a mix of both failed and passing jobs on the screen.
### Tested on

Firefox 15
Chrome 21
IE 9
IE 8 & 7 (in compatability mode)
