### PR TITLE
Adding a project name to the job to group them by it, on Radiator View

### DIFF
--- a/src/main/java/hudson/model/IViewEntry.java
+++ b/src/main/java/hudson/model/IViewEntry.java
@@ -3,7 +3,7 @@ package hudson.model;
 import java.util.Collection;
 
 /**
- * Interface for an entry on the radiator, which may be either a job or a group of jobs. 
+ * Interface for an entry on the radiator, which may be either a job or a group of jobs.
  */
 public interface IViewEntry {
 
@@ -11,6 +11,11 @@ public interface IViewEntry {
 	 * @return the job's name
 	 */
 	public abstract String getName();
+
+	/**
+	 * @return the job's radiator project name
+	 */
+	public abstract String getProjectName();
 
 	/**
 	 * @return if this job is queued for build
@@ -66,12 +71,12 @@ public interface IViewEntry {
 	/**
 	 * Elects a culprit/responsible for a broken build by choosing the last
 	 * commiter of a given build
-	 * 
+	 *
 	 * @return the culprit/responsible
 	 */
 	public abstract String getCulprit();
-	
-	
+
+
     public Collection<String> getCulprits();
 
 	/**
@@ -96,7 +101,7 @@ public interface IViewEntry {
 	/**
 	 * If the claims plugin is installed, this will get details of the claimed
 	 * build failures.
-	 * 
+	 *
 	 * @return details of any claims for the broken build, or null if nobody has
 	 *         claimed this build.
 	 */
@@ -108,7 +113,7 @@ public interface IViewEntry {
 	public abstract String getUnclaimedMatrixBuilds();
 
 	public abstract Result getLastFinishedResult();
-	
+
 	public abstract boolean hasChildren();
 
 	/**

--- a/src/main/java/hudson/model/JobViewEntry.java
+++ b/src/main/java/hudson/model/JobViewEntry.java
@@ -74,6 +74,16 @@ public class JobViewEntry implements IViewEntry {
 	/*
 	 * (non-Javadoc)
 	 * 
+	 * @see hudson.model.IViewEntry#getProjectName()
+	 */
+	public String getProjectName() {
+		RadiatorProjectProperty rpp = job.getProperty(RadiatorProjectProperty.class);
+		return (rpp != null) ? rpp.projectName : "";
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
 	 * @see hudson.model.IViewEntry#getQueued()
 	 */
 	public Boolean getQueued() {

--- a/src/main/java/hudson/model/ProjectViewEntry.java
+++ b/src/main/java/hudson/model/ProjectViewEntry.java
@@ -53,7 +53,7 @@ public class ProjectViewEntry implements IViewEntry {
 	 * least one failing job, then passing jobs also includes unstable ones. If
 	 * there's no failing job, then passing will only include stable jobs.
 	 * Unstable ones will be returned through {@link #getFailingJobs()}
-	 * 
+	 *
 	 * @return passing jobs (including unstable if there are jobs in failure).
 	 * @see #getFailingJobs()
 	 */
@@ -75,7 +75,7 @@ public class ProjectViewEntry implements IViewEntry {
 	 * Returns "failing" jobs. Depending on the context: failing will be jobs in
 	 * "real" failure (i.e. "red") if there are indeed some jobs of this sort.
 	 * If there aren't, then failing jobs will be unstable ones.
-	 * 
+	 *
 	 * @return "failing" jobs (unstable ones if no failing job is currently
 	 *         present).
 	 * @see #getPassingJobs()
@@ -140,6 +140,10 @@ public class ProjectViewEntry implements IViewEntry {
 	}
 
 	public String getName() {
+		return name;
+	}
+
+	public String getProjectName() {
 		return name;
 	}
 

--- a/src/main/java/hudson/model/RadiatorProjectProperty.java
+++ b/src/main/java/hudson/model/RadiatorProjectProperty.java
@@ -1,0 +1,48 @@
+package hudson.model;
+
+import hudson.Extension;
+import net.sf.json.JSONObject;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+
+public final class RadiatorProjectProperty extends
+		JobProperty<AbstractProject<?, ?>> {
+
+	public final String projectName;
+
+	@DataBoundConstructor
+	public RadiatorProjectProperty(final String projectName) {
+
+		this.projectName = projectName;
+	}
+
+	@Extension
+	public static final class DescriptorImpl extends JobPropertyDescriptor {
+
+		public DescriptorImpl() {
+			super(RadiatorProjectProperty.class);
+			load();
+		}
+
+		@Override
+		public boolean isApplicable(Class<? extends Job> jobType) {
+			return AbstractProject.class.isAssignableFrom(jobType);
+		}
+
+		@Override
+		public String getDisplayName() {
+			return "Radiator project name";
+		}
+
+		@Override
+		public JobProperty<?> newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+
+			if (formData.isEmpty()) {
+				return null;
+			}
+
+			return new RadiatorProjectProperty(formData.getString("projectName"));
+		}
+	}
+}

--- a/src/main/java/hudson/model/RadiatorView.java
+++ b/src/main/java/hudson/model/RadiatorView.java
@@ -163,7 +163,8 @@ public class RadiatorView extends ListView {
 		
 		for (IViewEntry job: allContents.getJobs())
 		{
-			String prefix = getPrefix(job.getName());
+			String projectName = job.getProjectName();
+			String prefix = StringUtils.isEmpty(projectName) ? getPrefix(job.getName()) : projectName;
 			ProjectViewEntry project = jobsByPrefix.get(prefix);
 			if (project == null)
 			{

--- a/src/main/resources/hudson/model/RadiatorProjectProperty/config.jelly
+++ b/src/main/resources/hudson/model/RadiatorProjectProperty/config.jelly
@@ -1,0 +1,15 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <!--
+    This jelly script is used for per-project configuration.
+
+    See global.jelly for a general discussion about jelly script.
+  -->
+
+  <!--
+    Creates a text field that shows the value of the "name" property.
+    When submitted, it will be passed to the corresponding constructor parameter.
+  -->
+  <f:entry title="${descriptor.getDisplayName()}" field="projectName" help="/plugin/radiatorviewplugin/help/displayName.html">
+    <f:textbox />
+  </f:entry>
+</j:jelly>

--- a/src/main/webapp/help/displayName.html
+++ b/src/main/webapp/help/displayName.html
@@ -1,0 +1,3 @@
+<div>
+<p>Set the name to be used as the group of related jobs, instead of use the start of the job's name.</p>
+</div>


### PR DESCRIPTION
If the user want, can set a project name to the job.
Jobs with same project name will be grouped on Radiator View. (updated version of #9 )
